### PR TITLE
Ajout de Infomaniak.com comme server dyndns

### DIFF
--- a/core/class/dyndns.class.php
+++ b/core/class/dyndns.class.php
@@ -257,7 +257,7 @@ class dyndns extends eqLogic {
 				$request_http = new com_http($url);
 				$request_http->setUserAgent('Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.0.12) Gecko/20070508 Firefox/1.5.0.12');
 				$result = $request_http->exec();
-				if (strpos($result, 'good') === false) {
+				if (strpos($result, 'good') === false && strpos($result, 'nochg') === false) {
 					throw new Exception(__('Erreur de mise à jour de infomaniak.com : ', __FILE__) . $result);
 				}
 				break;

--- a/core/class/dyndns.class.php
+++ b/core/class/dyndns.class.php
@@ -251,6 +251,16 @@ class dyndns extends eqLogic {
 					throw new Exception(__('Erreur de mise à jour de gandinet : ' . $url, __FILE__) . $result);
 				}
 				break;
+			case 'infomaniak':
+				$url = 'https://' . urlencode($this->getConfiguration('username')) . ':' . urlencode($this->getConfiguration('password')) . '@infomaniak.com/nic/update?hostname=' . $this->getConfiguration('hostname') .'&myip=' . $ip;
+				log::add('dyndns', 'debug', $url);
+				$request_http = new com_http($url);
+				$request_http->setUserAgent('Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.0.12) Gecko/20070508 Firefox/1.5.0.12');
+				$result = $request_http->exec();
+				if (strpos($result, 'good') === false) {
+					throw new Exception(__('Erreur de mise à jour de infomaniak.com : ', __FILE__) . $result);
+				}
+				break;
 		}
 	}
 

--- a/desktop/php/dyndns.php
+++ b/desktop/php/dyndns.php
@@ -100,10 +100,11 @@ foreach (jeedom::getConfiguration('eqLogic:category') as $key => $value) {
                 <option value="duckdns">www.duckdns.org</option>
                 <option value="stratocom">www.strato.com</option>
                 <option value="gandinet">www.gandi.net</option>
+                <option value="infomaniak">www.infomaniak.com</option>
             </select>
         </div>
     </div>
-    <div class="serviceType dyndnsorg noipcom ovhcom duckdns stratocom gandinet">
+    <div class="serviceType dyndnsorg noipcom ovhcom duckdns stratocom gandinet infomaniak">
         <div class="form-group">
             <label class="col-sm-3 control-label">{{Hostname}}</label>
             <div class="col-sm-3">
@@ -116,13 +117,13 @@ foreach (jeedom::getConfiguration('eqLogic:category') as $key => $value) {
                 <input type="text" class="eqLogicAttr form-control" data-l1key="configuration" data-l2key="domainname" />
              </div>
         </div>
-        <div class="form-group serviceType dyndnsorg noipcom ovhcom stratocom">
+        <div class="form-group serviceType dyndnsorg noipcom ovhcom stratocom infomaniak">
             <label class="col-sm-3 control-label">{{Nom d'utilisateur}}</label>
             <div class="col-sm-3">
                 <input type="text" class="eqLogicAttr form-control" data-l1key="configuration" data-l2key="username" />
             </div>
         </div>
-        <div class="form-group serviceType dyndnsorg noipcom ovhcom stratocom">
+        <div class="form-group serviceType dyndnsorg noipcom ovhcom stratocom infomaniak">
             <label class="col-sm-3 control-label">{{Mot de passe}}</label>
             <div class="col-sm-3">
                 <input type="password" class="eqLogicAttr form-control" data-l1key="configuration" data-l2key="password" />

--- a/docs/fr_FR/changelog.md
+++ b/docs/fr_FR/changelog.md
@@ -4,6 +4,7 @@
 >
 >Pour rappel s'il n'y a pas d'information sur la mise à jour, c'est que celle-ci concerne uniquement de la mise à jour de documentation, de traduction ou de texte
 
+- Support de Infomaniak.com
 - Support de l'ipv6 (merci @henribi)
 
 # 05/08/2021


### PR DESCRIPTION
Ajout de Infomaniak.com comme serveur de dyndns.
Tests avec utilisateurs réalisés à partir d'un fork du plugin.
Voir post sur Community: https://community.jeedom.com/t/dyndns-infomaniak/80893
